### PR TITLE
RBAC fix for serviceaccount creation in OpenShift

### DIFF
--- a/deploy/openshift/admin-elasticsearch-template.yaml
+++ b/deploy/openshift/admin-elasticsearch-template.yaml
@@ -11,13 +11,13 @@ objects:
 - apiVersion: apiextensions.k8s.io/v1beta1
   kind: CustomResourceDefinition
   metadata:
-    name: elasticsearchs.elasticsearch.redhat.com
+    name: elasticsearches.elasticsearch.redhat.com
   spec:
     group: elasticsearch.redhat.com
     names:
       kind: Elasticsearch
       listKind: ElasticsearchList
-      plural: elasticsearchs
+      plural: elasticsearches
       singular: elasticsearch
     scope: Namespaced
     version: v1alpha1
@@ -43,6 +43,7 @@ objects:
     - events
     - configmaps
     - secrets
+    - serviceaccounts
     verbs:
     - "*"
   - apiGroups:
@@ -54,6 +55,11 @@ objects:
     - statefulsets
     verbs:
     - "*"
+- kind: ServiceAccount
+  apiVersion: v1
+  metadata:
+    name: aggregated-logging-elasticsearch-operator
+    namespace: ${NAMESPACE}
 - kind: RoleBinding
   apiVersion: rbac.authorization.k8s.io/v1beta1
   metadata:
@@ -61,7 +67,7 @@ objects:
     namespace: ${NAMESPACE}
   subjects:
   - kind: ServiceAccount
-    name: default
+    name: aggregated-logging-elasticsearch-operator
   roleRef:
     kind: Role
     name: elasticsearch-operator

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -12,12 +12,13 @@ spec:
       labels:
         name: elasticsearch-operator
     spec:
+      serviceAccountName: aggregated-logging-elasticsearch-operator
       containers:
         - name: elasticsearch-operator
           image: quay.io/t0ffel/elasticsearch-operator
           command:
           - elasticsearch-operator
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: WATCH_NAMESPACE
               valueFrom:

--- a/deploy/rbac.yaml
+++ b/deploy/rbac.yaml
@@ -19,6 +19,7 @@ rules:
   - events
   - configmaps
   - secrets
+  - serviceaccounts
   verbs:
   - "*"
 - apiGroups:
@@ -33,13 +34,20 @@ rules:
 
 ---
 
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: aggregated-logging-elasticsearch-operator
+
+---
+
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: default-account-elasticsearch-operator
+  name: elasticsearch-operator-rolebinding
 subjects:
 - kind: ServiceAccount
-  name: default
+  name: aggregated-logging-elasticsearch-operator
 roleRef:
   kind: Role
   name: elasticsearch-operator


### PR DESCRIPTION
Added permission to create ServiceAccount on OpenShift.
Plural changed from elasticsearchs to elasticsearches.